### PR TITLE
Parameterized options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ ExampleAI/obj
 .DS_Store
 *.csproj.user
 CrystalAI/docs
+CrystalAI/packages.config

--- a/CrystalAI.Tests/CrystalAI.Tests.csproj
+++ b/CrystalAI.Tests/CrystalAI.Tests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Tests\Options\MultiplicativeUtilityOptionTests.cs" />
     <Compile Include="Tests\Options\OptionCollectionTests.cs" />
     <Compile Include="Tests\Options\OptionConstructorTests.cs" />
+    <Compile Include="Tests\Options\OptionParameterTests.cs" />
     <Compile Include="Tests\Options\WeightedMetricsTests.cs" />
     <Compile Include="Tests\Options\Helpers\Considerations.cs" />
     <Compile Include="Tests\Scheduling\DeferredCommandTests.cs" />
@@ -242,4 +243,5 @@
     </Content>
     <Content Include="Data\Readme.txt" />
   </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/CrystalAI.Tests/Tests/Options/GeneralOptionTests.cs
+++ b/CrystalAI.Tests/Tests/Options/GeneralOptionTests.cs
@@ -17,9 +17,9 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with Crystal AI.  If not, see <http://www.gnu.org/licenses/>.
-using System;
 using CrystalAI.TestHelpers;
 using NUnit.Framework;
+using System;
 
 
 #pragma warning disable

--- a/CrystalAI.Tests/Tests/Options/Helpers/Considerations.cs
+++ b/CrystalAI.Tests/Tests/Options/Helpers/Considerations.cs
@@ -17,7 +17,28 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with Crystal AI.  If not, see <http://www.gnu.org/licenses/>.
+
 namespace Crystal.OptionTests {
+
+  public class OptionParameters : IParameterProvider {
+    bool _power;
+
+    public bool Power {
+      get { return _power; }
+      set { _power = value; }
+    }
+
+    public OptionParameters() {
+    }
+
+    public OptionParameters(OptionParameters parameters) : this() {
+      Power = parameters.Power;
+    }
+
+    public IParameterProvider Clone() {
+      return new OptionParameters(this);
+    }
+  }
 
   public class OptionContext : IContext {
     float _xVal1;
@@ -28,6 +49,7 @@ namespace Crystal.OptionTests {
     float _xVal6;
     float _xVal7;
     float _xVal8;
+    float _xVal9;
 
     public float XVal1 {
       get { return _xVal1; }
@@ -67,6 +89,11 @@ namespace Crystal.OptionTests {
     public float XVal8 {
       get { return _xVal8; }
       set { _xVal8 = value.Clamp<float>(0.0f, 10.0f); }
+    }
+
+    public float XVal9 {
+      get { return _xVal9; }
+      set { _xVal9 = value.Clamp<float>(0.0f, 10.0f); }
     }
   }
 
@@ -321,6 +348,43 @@ namespace Crystal.OptionTests {
       cev.Add(ev1);
       cev.Add(ev2);
       _ev = cev;
+    }
+  }
+
+  public class OptionParametersConsideration : ConsiderationBase<OptionContext> {
+    IEvaluator _linear;
+    IEvaluator _power;
+
+    public override void Consider(OptionContext context) {
+      OptionParameters parameters = (OptionParameters)Parameters;
+
+      Utility = new Utility(parameters.Power ? _power.Evaluate(context.XVal9) : _linear.Evaluate(context.XVal9), Weight);
+    }
+
+    public override IConsideration Clone() {
+      return new OptionParametersConsideration(this);
+    }
+
+    public OptionParametersConsideration() {
+      Initialize();
+    }
+
+    OptionParametersConsideration(OptionParametersConsideration other) : base(other) {
+      Initialize();
+    }
+
+    public OptionParametersConsideration(string nameId, IConsiderationCollection collection) : base(nameId, collection) {
+      Initialize();
+    }
+
+    void Initialize() {
+      OptionParameters parameters = Parameters as OptionParameters;
+
+      var ptA = new Pointf(0f, 0f);
+      var ptB = new Pointf(10.0f, 1f);
+
+      _linear = new LinearEvaluator(ptA, ptB);
+      _power = new PowerEvaluator(ptA, ptB, 2);
     }
   }
 

--- a/CrystalAI.Tests/Tests/Options/OptionParameterTests.cs
+++ b/CrystalAI.Tests/Tests/Options/OptionParameterTests.cs
@@ -1,0 +1,97 @@
+﻿// GPL v3 License
+// 
+// Copyright (c) 2016-2017 Bismur Studios Ltd.
+// Copyright (c) 2016-2017 Ioannis Giagkiozis
+// 
+// OptionCollectionTests.cs is part of Crystal AI.
+//  
+// Crystal AI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//  
+// Crystal AI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Crystal AI.  If not, see <http://www.gnu.org/licenses/>.
+using CrystalAI.TestHelpers;
+using NUnit.Framework;
+
+namespace Crystal.OptionTests {
+
+  [TestFixture]
+  public class OptionParameterTests {
+    HelperAiConstructor _aiConstructor;
+
+    [OneTimeSetUp]
+    public void Initialize() {
+      _aiConstructor = new HelperAiConstructor();
+      SetupActionsAndConsiderations();
+    }
+
+    [Test]
+    public void AcceptsParametersTest() {
+      _aiConstructor.AIs.ClearAll();
+      OptionParameters parameters = new OptionParameters();
+      parameters.Power = true;
+
+      var o = new Option("o1", _aiConstructor.Options, parameters);
+      Assert.AreEqual(true, ((OptionParameters)o.Parameters).Power);
+    }
+
+    [Test]
+    public void ActionSharesParameterValues() {
+      _aiConstructor.AIs.ClearAll();
+      SetupActionsAndConsiderations();
+      OptionParameters parameters = new OptionParameters();
+      parameters.Power = true;
+
+      var o = new Option("o1", _aiConstructor.Options, parameters);
+      Assert.That(o.SetAction("a1"), Is.True);
+      Assert.AreEqual(parameters.Power, ((OptionParameters)o.Action.Parameters).Power);
+    }
+
+    [Test]
+    public void ConsiderationsCanUseParameterValues([Range(0.0f, 10.0f, 5f)] float util) {
+      _aiConstructor.AIs.ClearAll();
+      SetupActionsAndConsiderations();
+
+      OptionParameters linear = new OptionParameters();
+      linear.Power = false;
+      var linearOption = new Option("o2", _aiConstructor.Options, linear);
+      Assert.That(linearOption.SetAction("a2"), Is.True);
+      Assert.That(linearOption.AddConsideration("c1"), Is.True);
+
+      OptionParameters power = new OptionParameters();
+      power.Power = true;
+      var powerOption = new Option("o1", _aiConstructor.Options, power);
+      Assert.That(powerOption.SetAction("a1"), Is.True);
+      Assert.That(powerOption.AddConsideration("c1"), Is.True);
+
+
+      var context = new OptionContext();
+      context.XVal9 = util;
+      linearOption.Consider(context);
+      powerOption.Consider(context);
+
+      if(util == 0.0f || util == 10.0f) {
+        Assert.AreEqual(linearOption.Utility.Value, powerOption.Utility.Value);
+      }
+      else {
+        Assert.Greater(linearOption.Utility.Value, powerOption.Utility.Value);
+      }
+    }
+
+    void SetupActionsAndConsiderations() {
+      _aiConstructor.AIs.ClearAll();
+
+      var tmpa = new MockAction("a1", _aiConstructor.Actions);
+      tmpa = new MockAction("a2", _aiConstructor.Actions);
+
+      var tmpc = new OptionParametersConsideration("c1", _aiConstructor.Considerations);
+    }
+  }
+}

--- a/CrystalAI/CrystalAI.csproj
+++ b/CrystalAI/CrystalAI.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Source\Options\OptionConstructor.cs" />
     <Compile Include="Source\Options\Interfaces\IOption.cs" />
     <Compile Include="Source\Options\Interfaces\IOptionCollection.cs" />
+    <Compile Include="Source\Parameters\Interfaces\IParameterProvider.cs" />
     <Compile Include="Source\Scheduling\QueuedCommand.cs" />
     <Compile Include="Source\Utilities\Pcg.cs" />
     <Compile Include="Source\Utilities\PcgExtended.cs" />
@@ -125,5 +126,7 @@
     <Compile Include="Source\Extensions\ReaderWriterLockSlimExtensions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/CrystalAI/Source/Actions/ActionBase.cs
+++ b/CrystalAI/Source/Actions/ActionBase.cs
@@ -84,6 +84,12 @@ namespace Crystal {
       protected set { _actionStatus = value; }
     }
 
+    /// <summary>
+    ///   Optional parameters for this action.
+    /// </summary>
+    /// <value>The action parameters.</value>
+    public IParameterProvider Parameters { get; set; }
+
     /// <summary>Executes the action.</summary>
     /// <param name="context">The context.</param>
     public void Execute(IContext context) {
@@ -172,6 +178,7 @@ namespace Crystal {
       _collection = other._collection;
       Cooldown = other.Cooldown;
       _cooldownTimer = new Stopwatch();
+      Parameters = other.Parameters?.Clone();
     }
 
     /// <summary>
@@ -190,6 +197,17 @@ namespace Crystal {
       NameId = nameId;
       _collection = collection;
       AddSelfToCollection();
+    }
+    /// <summary>
+    ///   Initializes a new instance of the <see cref="ActionBase"/> class.
+    /// </summary>
+    /// <param name="nameId">The name identifier.</param>
+    /// <param name="collection">The collection.</param>
+    /// <param name="parameters">The parameters.</param>
+    /// <exception cref="Crystal.ActionBase.NameIdEmptyOrNullException"></exception>
+    /// <exception cref="Crystal.ActionBase.ActionCollectionNullException"></exception>
+    public ActionBase(string nameId, IActionCollection collection, IParameterProvider parameters) : this(nameId, collection) {
+      Parameters = parameters;
     }
 
     bool CanExecute() {

--- a/CrystalAI/Source/Actions/GenericActionBase.cs
+++ b/CrystalAI/Source/Actions/GenericActionBase.cs
@@ -83,6 +83,12 @@ namespace Crystal {
     }
 
     /// <summary>
+    ///   Optional parameters for this action.
+    /// </summary>
+    /// <value>The action parameters.</value>
+    public IParameterProvider Parameters { get; set; }
+
+    /// <summary>
     ///   Executes the specified context.
     /// </summary>
     /// <param name="context">The context.</param>

--- a/CrystalAI/Source/Actions/Interfaces/IAction.cs
+++ b/CrystalAI/Source/Actions/Interfaces/IAction.cs
@@ -51,6 +51,11 @@ namespace Crystal {
     ActionStatus ActionStatus { get; }
 
     /// <summary>
+    ///   Optional parameters for this action.
+    /// </summary>
+    IParameterProvider Parameters { get; set; }
+
+    /// <summary>
     ///   Executes the AI Action.
     /// </summary>
     /// <param name="context">AI Context.</param>

--- a/CrystalAI/Source/Actors/AiCollection.cs
+++ b/CrystalAI/Source/Actors/AiCollection.cs
@@ -36,7 +36,7 @@ namespace Crystal {
     ///   All behaviours available to this AiCollection.
     /// </summary>
     public IBehaviourCollection Behaviours { get; private set; }
-    
+
     /// <summary>
     ///   All options available to this AiCollection.
     /// </summary>

--- a/CrystalAI/Source/Behaviours/Behaviour.cs
+++ b/CrystalAI/Source/Behaviours/Behaviour.cs
@@ -70,6 +70,7 @@ namespace Crystal {
     /// Adds the option associated with optionId, if one exists.
     /// </summary>
     /// <param name="optionId">The option identifier.</param>
+    /// <param name="parameters">The parameters.</param>
     /// <returns>
     /// Returns true if the option was successfully added, false otherwise.
     /// </returns>

--- a/CrystalAI/Source/Considerations/CompositeConsideration.cs
+++ b/CrystalAI/Source/Considerations/CompositeConsideration.cs
@@ -75,6 +75,12 @@ namespace Crystal {
     public Utility Utility { get; protected set; }
 
     /// <summary>
+    ///   Optional parameters for this action.
+    /// </summary>
+    /// <value>The action parameters.</value>
+    public IParameterProvider Parameters { get; set; }
+
+    /// <summary>
     ///   Gets the weight of this consideration.
     /// </summary>
     public float Weight {
@@ -105,7 +111,7 @@ namespace Crystal {
     /// </summary>
     /// <param name="consideration"></param>
     /// <returns></returns>
-    public bool AddConsideration(IConsideration consideration) {
+    public virtual bool AddConsideration(IConsideration consideration) {
       if(consideration == null)
         return false;
       if(_considerations.Contains(consideration))
@@ -132,8 +138,9 @@ namespace Crystal {
       if(_collection.Contains(considerationId) == false)
         return false;
 
-      InternalAddConsideration(considerationId);
-      return true;
+
+      IConsideration consideration = _collection.Create(considerationId);
+      return AddConsideration(consideration);
     }
 
     /// <summary>
@@ -242,11 +249,6 @@ namespace Crystal {
 
     void InternalAddConsideration(IConsideration c) {
       _considerations.Add(c);
-      _considerationUtilities.Add(new Utility(0.0f, 0.0f));
-    }
-
-    void InternalAddConsideration(string nameId) {
-      _considerations.Add(_collection.Create(nameId));
       _considerationUtilities.Add(new Utility(0.0f, 0.0f));
     }
 

--- a/CrystalAI/Source/Considerations/ConsiderationBase.cs
+++ b/CrystalAI/Source/Considerations/ConsiderationBase.cs
@@ -78,6 +78,11 @@ namespace Crystal {
       }
     }
 
+    /// <summary>
+    ///   Optional parameters for this consideration.
+    /// </summary>
+    public IParameterProvider Parameters { get; set; }
+
     /// <summary>Calculates the utility given the specified context.</summary>
     /// <param name="context">The context.</param>
     public abstract void Consider(IContext context);
@@ -108,6 +113,7 @@ namespace Crystal {
       DefaultUtility = other.DefaultUtility;
       Utility = other.Utility;
       Weight = other.Weight;
+      Parameters = other.Parameters?.Clone();
     }
 
     /// <summary>
@@ -125,6 +131,18 @@ namespace Crystal {
       _collection = collection;
       if(_collection.Add(this) == false)
         throw new ConsiderationAlreadyExistsInCollectionException(nameId);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="T:Crystal.ConsiderationBase"/> class.
+    /// </summary>
+    /// <param name="nameId">The name identifier.</param>
+    /// <param name="collection">The collection.</param>
+    /// <param name="parameters">The parameters.</param>
+    /// <exception cref="T:Crystal.ConsiderationBase.ConsiderationCollectionNullException"></exception>
+    /// <exception cref="T:Crystal.ConsiderationBase.ConsiderationAlreadyExistsInCollectionException"></exception>
+    protected ConsiderationBase(string nameId, IConsiderationCollection collection, IParameterProvider parameters) : this(nameId, collection) {
+      Parameters = parameters;
     }
 
     internal class ConsiderationCollectionNullException : Exception {

--- a/CrystalAI/Source/Considerations/GenericConsiderationBase.cs
+++ b/CrystalAI/Source/Considerations/GenericConsiderationBase.cs
@@ -57,6 +57,12 @@ namespace Crystal {
     public Utility Utility { get; protected set; }
 
     /// <summary>
+    ///   Returns the parameters for this consideration.
+    /// </summary>
+    /// <value>The parameters.</value>
+    public IParameterProvider Parameters { get; set; }
+
+    /// <summary>
     ///   The weight of this consideration.
     /// </summary>
     public float Weight {

--- a/CrystalAI/Source/Considerations/Interfaces/IConsideration.cs
+++ b/CrystalAI/Source/Considerations/Interfaces/IConsideration.cs
@@ -50,6 +50,11 @@ namespace Crystal {
     /// </summary>
     bool IsInverted { get; set; }
 
+    /// <summary>
+    ///   Optional parameters for this consideration.
+    /// </summary>
+    IParameterProvider Parameters { get; set; }
+
     /// <summary>Calculates the utility given the specified context.</summary>
     /// <param name="context">The context.</param>
     /// <returns>The utility.</returns>

--- a/CrystalAI/Source/Options/Option.cs
+++ b/CrystalAI/Source/Options/Option.cs
@@ -63,6 +63,19 @@ namespace Crystal {
         return false;
 
       Action = _collection.Actions.Create(actionId);
+      Action.Parameters = Parameters?.Clone();
+      return true;
+    }
+
+    /// <summary>
+    /// Add the specified consideration
+    /// </summary>
+    /// <param name="consideration"></param>
+    /// <returns></returns>
+    public override bool AddConsideration(IConsideration consideration) {
+      if(!base.AddConsideration(consideration))
+        return false;
+      consideration.Parameters = Parameters?.Clone();
       return true;
     }
 
@@ -105,6 +118,7 @@ namespace Crystal {
       Weight = other.Weight;
       Measure = other.Measure?.Clone();
       Action = other.Action?.Clone();
+      Parameters = other.Parameters?.Clone();
     }
 
     /// <summary>
@@ -119,6 +133,18 @@ namespace Crystal {
       Initialize();
       if(_collection.Add(this) == false)
         throw new OptionAlreadyExistsInCollectionException(nameId);
+    }
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="T:Crystal.Option"/> class with <see cref="T:Crystal.IParameterProvider"/> parameters.
+    /// </summary>
+    /// <param name="nameId">The name identifier.</param>
+    /// <param name="collection">The collection.</param>
+    /// <param name="parameters">The parameters.</param>
+    /// <exception cref="T:Crystal.Option.OptionAlreadyExistsInCollectionException"></exception>
+    public Option(string nameId, IOptionCollection collection, IParameterProvider parameters) : this(nameId, collection) {
+      Parameters = parameters;
     }
 
     void Initialize() {

--- a/CrystalAI/Source/Options/OptionCollection.cs
+++ b/CrystalAI/Source/Options/OptionCollection.cs
@@ -61,7 +61,7 @@ namespace Crystal {
       _optionsMap.Add(option.NameId, option);
       return true;
     }
-    
+
     /// <summary>
     /// Determines whether this collection contains the option associated with the
     /// specified identifier.

--- a/CrystalAI/Source/Parameters/Interfaces/IParameterProvider.cs
+++ b/CrystalAI/Source/Parameters/Interfaces/IParameterProvider.cs
@@ -1,0 +1,29 @@
+﻿// GPL v3 License
+// 
+// Copyright (c) 2016-2017 Bismur Studios Ltd.
+// Copyright (c) 2016-2017 Ioannis Giagkiozis
+// 
+// IParameterProvider.cs is part of Crystal AI.
+//  
+// Crystal AI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//  
+// Crystal AI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Crystal AI.  If not, see <http://www.gnu.org/licenses/>.
+namespace Crystal {
+
+  /// <summary>
+  ///   Provides parameters to <see cref="T:Crystal.IOption"/>, <see cref="T:Crystal.IAction"/>, and <see cref="T:Crystal.IConsideration"/>.
+  ///   These can be used to provide additional hints in addition to the <see cref="T:Crystal.IContext"/>.
+  /// </summary>
+  public interface IParameterProvider : IAiPrototype<IParameterProvider> {
+  }
+
+}


### PR DESCRIPTION
## Why?

This PR proposes the ability to provide additional information to your `Action`s and `Consideration`s via a `IParameterProvider` set on the parent `Option`.

Here is my scenario that I was unable to solve with the current `Context` alone.

- A `Ship` has many `Turret`s
- `Turret`s are not unique, meaning there can be many of the same `Turret` on the Ship
- The AI is sitting on the `Ship`, the AI needs to weigh the option of firing each `Turret` against every other `Turret`

My AI uses a `ShipContext`, which in turns contains a `Ship` reference. 

When building `Action`s and `Consideration`s for firing each `Turret`, I need the ability to specify which `Turret` to look up in the `Context`. Examples of generic (all turrets share the same consideration) considerations:

- `TurretOnCooldownConsideration`
- `TurretEnergyAvailableConsideration`
- `TurretNearDestructionConsideration`

Each of these considerations can fetch `shipContext.Ship.Turrets`, but need an additional hint to determine what `Turret`s values to use with the `Utility` evaluator. 

```c#
class TurretParameters : IParameterProvider {
  public int TurretSlot; 
}
```

Solves this by giving me the ability to 

```c#
Consider() {
  TurretParameters params = (TurretParameters)Parameters;
  Turret turret = shipContext.Ship.Turrets[params.TurretSlot];
  // turret.Cooldown
}
```

# How?

`IConsideration` and `IAction` are given a `IParameterProvider Parameters` property.  The `Option` in turn gets its `Parameters` via its `IConsideration > ICompositeConsideration > CompositeConsideration > Option` inheritance. 

When `SetAction` and `AddConsideration` are called on `Option`, the `Parameters` are cloned and set on the respective actions and considerations. They can use them by casting their `IParameterProvider Parameters` reference to the appropriate subclass of `IParameterProvider`. This has the implicit contract of the `Action` and `Consideration` being aware of what type of Parameters they use.

@ThelDoctor let me know how this looks. I'm *fairly* happy with the tests as they are now, but I suspect there may be a few areas I could change. 